### PR TITLE
Use bound-fn for newly created threads

### DIFF
--- a/src/ip_geoloc/maxmind.clj
+++ b/src/ip_geoloc/maxmind.clj
@@ -318,7 +318,7 @@
   (let [stopped (atom false)
         thread
         (Thread.
-         (fn []
+         (bound-fn []
            (println "background thread to update ip-geoloc db started!")
            (loop []
 


### PR DESCRIPTION
With that we can control threads' output via an `*out*` binding, so the printlns go to one's logging solution of choice.

Thanks for the library!

Victor