### PR TITLE
Minor fixes

### DIFF
--- a/src/ip_geoloc/maxmind.clj
+++ b/src/ip_geoloc/maxmind.clj
@@ -362,7 +362,7 @@
       ;; if a specific file has been chosen
       ;; use that one with no update
       database-file
-      (swap! provider (init (MaxMind2. database-file nil)))
+      (swap! provider (constantly (init (MaxMind2. database-file nil))))
       ;; if a folder it is used then
       ;; then we look for the last db available
       database-folder

--- a/src/ip_geoloc/maxmind.clj
+++ b/src/ip_geoloc/maxmind.clj
@@ -381,9 +381,10 @@
 
 (defn stop-maxmind [{:keys [provider update-thread] :as cfg}]
   ;; stopping update thread
-  (@update-thread)
+  (when-let [ut (some-> update-thread deref)]
+    (ut))
   ;; stopping db
-  (close @provider)
+  (some-> provider deref close)
   ;; resetting reference
   (swap! provider (constantly nil))
   ;; updated state


### PR DESCRIPTION
2 commits:

## Fix an usage of `swap!`

As you can see below the affected lines, `constantly` was the pattern to use.

(or, the 3 `swap` + `constantly` combos could be simply replaced with `reset!`...)

## Make `stop-maxmind` idempotent

It was causing issues under the Reloaded workflow.

Cheers - Victor