### PR TITLE
update-db: introduce fixed-filename option

### DIFF
--- a/src/ip_geoloc/maxmind.clj
+++ b/src/ip_geoloc/maxmind.clj
@@ -251,10 +251,13 @@
 
 
 
-(defn update-db [{:keys [database-url database-md5-url database-folder]}]
+(defn update-db [{:keys [database-url database-md5-url database-folder]
+                  ::keys [initial?]}]
   (let [dbgz (io/file database-folder "GeoLite2-City.mmdb.gz")
         db   (io/file database-folder
-                      (str "GeoLite2-City.mmdb." (System/currentTimeMillis)))]
+                      (str "GeoLite2-City.mmdb." (if initial?
+                                                   0
+                                                   (System/currentTimeMillis))))]
     (download-db database-url dbgz)
     (gunzip-file dbgz db)
     (if (check-db (fetch-db-md5 database-md5-url) db)


### PR DESCRIPTION
Hi again!

As an intended production setup, I want to invoke `update-db` directly, once, prior to deployments, in order to deploy an uberjar with that .ok file.

That way we don't have to fear "what if MaxMind connectivity is down", etc.

So, this PR introduces a `fixed-filename` option. That way we don't have to figure out what the downloaded file was, making things more reliable.

Worth nothing, `fixed-filename` is not an intended part of the global configuration. Perhaps it would be clearer by using a qualified key instead:  `:update-db/fixed-filename`.

WYDT?

Cheers - Victor